### PR TITLE
Add support for running with simulation time

### DIFF
--- a/leg_controller/leg_controller.h
+++ b/leg_controller/leg_controller.h
@@ -48,9 +48,9 @@ namespace champ
             }
 
         public:
-            LegController(QuadrupedBase &quadruped_base):
+            LegController(QuadrupedBase &quadruped_base, PhaseGenerator::Time time = PhaseGenerator::now()):
                 base_(&quadruped_base),     
-                phase_generator(quadruped_base),
+                phase_generator(quadruped_base, time),
                 lf(base_->lf),
                 rf(base_->rf),
                 lh(base_->lh),
@@ -90,7 +90,7 @@ namespace champ
                 return (stance_duration / 2.0f) * target_velocity;
             }
 
-            void velocityCommand(geometry::Transformation (&foot_positions)[4], champ::Velocities &req_vel)
+            void velocityCommand(geometry::Transformation (&foot_positions)[4], champ::Velocities &req_vel, PhaseGenerator::Time time = PhaseGenerator::now())
             {
                 //limit all velocities to user input
                 req_vel.linear.x = capVelocities(req_vel.linear.x, -base_->gait_config.max_linear_velocity_x, base_->gait_config.max_linear_velocity_x);
@@ -121,7 +121,7 @@ namespace champ
                 }
 
                 //create a saw tooth signal gen so the trajectory planner knows whether it should swing or stride
-                phase_generator.run(velocity, sum_of_steps / 4.0f);
+                phase_generator.run(velocity, sum_of_steps / 4.0f, time);
 
                 for(unsigned int i = 0; i < 4; i++)
                 {

--- a/leg_controller/phase_generator.h
+++ b/leg_controller/phase_generator.h
@@ -35,16 +35,21 @@ namespace champ
 {
     class PhaseGenerator
     {
+        public:
+            typedef unsigned long int Time;
+            static inline Time now() { return time_us(); }
+
+        private:
             champ::QuadrupedBase *base_;
 
-            unsigned long int last_touchdown_;
+            Time last_touchdown_;
 
             bool has_swung_;
 
         public:
-            PhaseGenerator(champ::QuadrupedBase &base):
+            PhaseGenerator(champ::QuadrupedBase &base, Time time = now()):
                 base_(&base),
-                last_touchdown_(time_us()),
+                last_touchdown_(time),
                 has_swung_(false),
                 has_started(false),
                 stance_phase_signal{0.0f,0.0f,0.0f,0.0f},
@@ -52,7 +57,7 @@ namespace champ
             {
             }        
 
-            void run(float target_velocity, float step_length)
+            void run(float target_velocity, float step_length, Time time = now())
             {
                 unsigned long elapsed_time_ref = 0;
                 float swing_phase_period = 0.25f * SECONDS_TO_MICROS;
@@ -77,18 +82,18 @@ namespace champ
                 if(!has_started)
                 {
                     has_started = true;
-                    last_touchdown_ = time_us();
+                    last_touchdown_ = time;
                 }
 
-                if((time_us() - last_touchdown_) >= stride_period)
+                if((time - last_touchdown_) >= stride_period)
                 {
-                    last_touchdown_ = time_us();
+                    last_touchdown_ = time;
                 }
 
                 if(elapsed_time_ref >= stride_period)
                     elapsed_time_ref = stride_period;
                 else
-                    elapsed_time_ref = time_us() - last_touchdown_;
+                    elapsed_time_ref = time - last_touchdown_;
 
                 leg_clocks[0] = elapsed_time_ref - (0.0f * stride_period);
                 leg_clocks[1] = elapsed_time_ref - (0.5f * stride_period);


### PR DESCRIPTION
This PR substitutes all usages of `time_us()` macro by a parameter that can be passed from external code and defaults to `time_us()`. This way, the library will remain 100% backwards compatible while allowing users to utilize the newly added support for passing other time than system clock.

To compare, here are graphs of one joint command plotted at various real-time factors when running CHAMP in Gazebo. All graphs share the same scale of both x and y axes. The same `cmd_vel` command was used in all experiments.

Without this PR:

RTF 0.1

![Snímek z 2021-03-23 23-31-37](https://user-images.githubusercontent.com/182533/112231449-06cb2a80-8c37-11eb-90e4-1cdeb56fc83b.png)

RTF 1.0 (or what my machine can do, approx. 0.6-0.8)

![Snímek z 2021-03-23 23-33-18](https://user-images.githubusercontent.com/182533/112231481-15194680-8c37-11eb-8f20-d706c93e4b59.png)

With this PR:

RTF 0.1

![Snímek z 2021-03-24 00-10-19](https://user-images.githubusercontent.com/182533/112231502-1f3b4500-8c37-11eb-9761-0bb1a599cbe5.png)

RTF 1.0 (or what my machine can do, approx. 0.6-0.8)

![Snímek z 2021-03-24 00-11-40](https://user-images.githubusercontent.com/182533/112231519-282c1680-8c37-11eb-85f0-2d337d6dd719.png)
